### PR TITLE
Provided a custom implementation of Wrapper

### DIFF
--- a/Bossa/PhpSpec/Expect/Wrapper.php
+++ b/Bossa/PhpSpec/Expect/Wrapper.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Bossa\PhpSpec\Expect;
+
+use PhpSpec\Exception\ExceptionFactory;
+use PhpSpec\Runner\MatcherManager;
+use PhpSpec\Formatter\Presenter\PresenterInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use PhpSpec\Loader\Node\ExampleNode;
+
+use PhpSpec\Wrapper\Subject\WrappedObject;
+use PhpSpec\Wrapper\Subject\Caller;
+use PhpSpec\Wrapper\Subject\SubjectWithArrayAccess;
+use PhpSpec\Wrapper\Subject\ExpectationFactory;
+use PhpSpec\Wrapper\Wrapper as BaseWrapper;
+
+class Wrapper extends BaseWrapper
+{
+    private $matchers;
+    private $presenter;
+    private $dispatcher;
+    private $example;
+
+    public function __construct(MatcherManager $matchers, PresenterInterface $presenter,
+        EventDispatcherInterface $dispatcher, ExampleNode $example)
+    {
+        $this->matchers = $matchers;
+        $this->presenter = $presenter;
+        $this->dispatcher = $dispatcher;
+        $this->example = $example;
+    }
+
+    public function wrap($value = null)
+    {
+        $exceptionFactory   = new ExceptionFactory($this->presenter);
+        $wrappedObject      = new WrappedObject($value, $this->presenter);
+        $caller             = new Caller($wrappedObject, $this->example, $this->dispatcher, $exceptionFactory, $this);
+        $arrayAccess        = new SubjectWithArrayAccess($caller, $this->presenter, $this->dispatcher);
+        $expectationFactory = new ExpectationFactory($this->example, $this->dispatcher, $this->matchers);
+
+        return new Subject(
+            $value, $this, $wrappedObject, $caller, $arrayAccess, $expectationFactory
+        );
+    }
+}
+

--- a/expect.php
+++ b/expect.php
@@ -15,6 +15,7 @@ if (is_dir($vendor = __DIR__ . '/../vendor')) {
 }
 
 use Bossa\PhpSpec\Expect\Subject;
+use Bossa\PhpSpec\Expect\Wrapper;
 use PhpSpec\Exception\ExceptionFactory;
 use PhpSpec\Formatter\Presenter\Differ\Differ;
 use PhpSpec\Formatter\Presenter\TaggedPresenter;
@@ -40,10 +41,10 @@ use PhpSpec\Wrapper\Subject\ExpectationFactory;
 use PhpSpec\Wrapper\Subject\SubjectWithArrayAccess;
 use PhpSpec\Wrapper\Subject\WrappedObject;
 use PhpSpec\Wrapper\Unwrapper;
-use PhpSpec\Wrapper\Wrapper;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 require_once 'Bossa/PhpSpec/Expect/Subject.php';
+require_once 'Bossa/PhpSpec/Expect/Wrapper.php';
 
 if (!function_exists('expect')) {
     function expect($sus)


### PR DESCRIPTION
 To make sure that wrapper creates a custom Subject implementation, as a quick fix I provided a custom Wrapper. 

The Wrapper is basically copied over so I treat it as a temporary implementation.

Expressions like the following one started to fail with a recent PhpSpec update:

``` php
<?php

require_once __DIR__.'/vendor/autoload.php';

class User
{
    public function getName()
    {
        return 'Kuba';
    }
}

expect(new User())->getName()->toBe('Kuba');

```

``` bash
PHP Fatal error:  Uncaught exception 'ReflectionException' with message 'Class  does not exist' in /home/jzalas/Projects/phpspec2-expect/vendor/phpspec/phpspec/src/PhpSpec/Util/Instantiator.php:17
Stack trace:
#0 /home/jzalas/Projects/phpspec2-expect/vendor/phpspec/phpspec/src/PhpSpec/Util/Instantiator.php(17): ReflectionClass->__construct('')
#1 /home/jzalas/Projects/phpspec2-expect/vendor/phpspec/phpspec/src/PhpSpec/Util/Instantiator.php(12): PhpSpec\Util\Instantiator->createSerializedObject(NULL)
#2 /home/jzalas/Projects/phpspec2-expect/vendor/phpspec/phpspec/src/PhpSpec/Exception/ExceptionFactory.php(21): PhpSpec\Util\Instantiator->instantiate(NULL)
#3 /home/jzalas/Projects/phpspec2-expect/vendor/phpspec/phpspec/src/PhpSpec/Wrapper/Subject/Caller.php(213): PhpSpec\Exception\ExceptionFactory->methodNotFound(NULL, 'toBe', Array)
#4 /home/jzalas/Projects/phpspec2-expect/vendor/phpspec/phpspec/src/PhpSpec/Wrapper/Subject/Caller.php(53): PhpSpec\Wrapper\Subject\Caller->methodNotFound('toBe', Array)
#5 /home/jzalas/Projects/phps in /home/jzalas/Projects/phpspec2-expect/vendor/phpspec/phpspec/src/PhpSpec/Util/Instantiator.php on line 17
```
