### PR TITLE
Handle situation when `expect` is executed inside of abstract class.

### DIFF
--- a/expect.php
+++ b/expect.php
@@ -53,10 +53,7 @@ if (!function_exists('expect')) {
 
         $trace = debug_backtrace();
         if (isset($trace[1]['object'])) {
-
-            $class = get_class($trace[1]['object']);
-            $serialized = sprintf('O:%u:"%s":0:{}', strlen($class), $class);
-            $object = unserialize($serialized);
+            $object = $trace[1]['object'];
 
             if ($object instanceof MatchersProviderInterface) {
                 foreach ($object->getMatchers() as $name => $matcher) {


### PR DESCRIPTION
By mistake I removed my branch for previous PR https://github.com/BossaConsulting/phpspec2-expect/pull/16

Problem occurs for classes that extend abstract class which executes `expect` function. 
In my case it's behat's context file with some default steps.

How to reproduce:

``` php
<?php

include 'vendor/autoload.php';

abstract class MyAbstract
{
    public function run()
    {
        expect(true)->toBe(true);
    }
}

class MyClass extends MyAbstract
{
}

$obj = new MyClass();
$obj->run();

// PHP Fatal error:  Cannot instantiate abstract class MyAbstract in /vagrant/vendor/bossa/phpspec2-expect/expect.php on line 76
```
