### PR TITLE
Add support for phpspec's ArrayKeyValueMatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
         }
     },
     "require": {
-        "phpspec/phpspec": "~2.0"
+        "phpspec/phpspec": "^2.2"
     }
 }

--- a/expect.php
+++ b/expect.php
@@ -9,6 +9,7 @@ use PhpSpec\Loader\Node\ExampleNode;
 use PhpSpec\Matcher\ArrayContainMatcher;
 use PhpSpec\Matcher\ArrayCountMatcher;
 use PhpSpec\Matcher\ArrayKeyMatcher;
+use PhpSpec\Matcher\ArrayKeyValueMatcher;
 use PhpSpec\Matcher\CallbackMatcher;
 use PhpSpec\Matcher\ComparisonMatcher;
 use PhpSpec\Matcher\IdentityMatcher;
@@ -46,6 +47,7 @@ if (!function_exists('expect')) {
         $matchers->add(new ScalarMatcher($presenter));
         $matchers->add(new ArrayCountMatcher($presenter));
         $matchers->add(new ArrayKeyMatcher($presenter));
+        $matchers->add(new ArrayKeyValueMatcher($presenter));
         $matchers->add(new ArrayContainMatcher($presenter));
         $matchers->add(new StringStartMatcher($presenter));
         $matchers->add(new StringEndMatcher($presenter));


### PR DESCRIPTION
This adds support for the [ArrayKeyWithValue Matcher](http://www.phpspec.net/en/latest/cookbook/matchers.html#arraykeywithvalue-matcher) added in phpspec 2.2.0. 