### PR TITLE
Enable disabling expect() function by environment variable

### DIFF
--- a/expect.php
+++ b/expect.php
@@ -29,7 +29,13 @@ use PhpSpec\Wrapper\Subject\WrappedObject;
 use PhpSpec\Wrapper\Unwrapper;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-if (!function_exists('expect')) {
+$useExpect = true;
+
+if (getenv('PHPSPEC_DISABLE_EXPECT') || (defined('PHPSPEC_DISABLE_EXPECT') && PHPSPEC_DISABLE_EXPECT)) {
+    $useExpect = false;
+}
+
+if ($useExpect && !function_exists('expect')) {
     function expect($sus)
     {
         $presenter = new TaggedPresenter(new Differ);


### PR DESCRIPTION
In our current test setup we're using both PHPSpec2 Expect and Kahlan. Unfortunately both are using autoloading of expect() functions in composer. Kahlan has ability to disable its expect using environment variable. To properly run kahlans we needed ability to disable PHPSpec2 expect. That way we can run Kahlan or PHPSpec flawlessy.