### PR TITLE
Amend checking class names in class_exists

### DIFF
--- a/expect.php
+++ b/expect.php
@@ -73,13 +73,13 @@ if ($useExpect && !function_exists('expect')) {
         $matchers->add(new StringEndMatcher($presenter));
         $matchers->add(new StringRegexMatcher($presenter));
         $matchers->add(new StringContainMatcher($presenter));
-        if (class_exists('TriggerMatcher')) {
+        if (class_exists(TriggerMatcher::class)) {
             $matchers->add(new TriggerMatcher($unwrapper));
         }
-        if (class_exists('IterateAsMatcher')) {
+        if (class_exists(IterateAsMatcher::class)) {
             $matchers->add(new IterateAsMatcher($presenter));
         }
-        if (class_exists('ApproximatelyMatcher')) {
+        if (class_exists(ApproximatelyMatcher::class)) {
             $matchers->add(new ApproximatelyMatcher($presenter));
         }
 


### PR DESCRIPTION
There are problems with existsing configuration of phpspec.

Class **TriggerMatcher** and the others could not be found, this could resolve this problem.