### PR TITLE
Get Composer to run on PHP 7.3 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,18 @@ cache:
 matrix:
   include:
     - php: 7.1
-      env: DEPENDENCIES='low'
+      env: COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.1
     - php: 7.2
-      env: DEPENDENCIES='low'
-    - php: 7.2
     - php: nightly
+      env: COMPOSER_FLAGS='--ignore-platform-reqs'
   allow_failures:
     - php: nightly
   fast_finish: true
 
 install:
-  - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
-  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
+  - echo "Composer flags are '$COMPOSER_FLAGS'"
+  - composer update $COMPOSER_FLAGS
 
 script:
    - ./vendor/bin/phpunit


### PR DESCRIPTION
`php nightly` build on Travis was broken. This is because Composer can't install PhpSpec with PHP 7.3 release candidates. This PR adds `--ignore-platform-reqs` to the Composer command.

This build job was an 'allowable failure' before, but now it passes.