### PR TITLE
Support PHP 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 8.0
     - php: nightly
       env: COMPOSER_FLAGS='--ignore-platform-reqs'
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     },
     "require": {
-        "php": "^7.1",
-        "phpspec/phpspec": "^5.0 || ^6.0"
+        "php": "^7.1 || ^8.0",
+        "phpspec/phpspec": "^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0 || ^8.5 || ^9.5"
     }
 }


### PR DESCRIPTION
which will want to use `phpunit` 9 for testing...

This will help upstream projects move forward with PHP 8.0 support.